### PR TITLE
feat: add CSS class to window contents.

### DIFF
--- a/src/components/BaseWindow/BaseWindow.js
+++ b/src/components/BaseWindow/BaseWindow.js
@@ -20,7 +20,7 @@ export default function BaseWindow({ id, title, children, onReset, onHide }) {
   }
 
   return (
-    <Card className={"window window-" + title + " "} sx={{ minWidth: 275 }}>
+    <Card className={"window window-" + id + " "} sx={{ minWidth: 275 }}>
       <Box
         className="drag-handle"
         sx={{
@@ -51,8 +51,8 @@ export default function BaseWindow({ id, title, children, onReset, onHide }) {
         </IconButton>
       </Box>
 
-      <CardContent>
-        <Container disableGutters={true} className="window-content">
+      <CardContent className="window-content">
+        <Container disableGutters={true} className="content-container">
           {children}
         </Container>
       </CardContent>


### PR DESCRIPTION
Adds a dedicated css selector to BaseWindow Content (window-content), fixes adaptive css selector for BaseWindow Card (used to be window-{title} but needs to be window-{id}).

**Reviewer's task:**
- [x] I didn't see no code smells
- [x] The live preview works as expected -> no regressions found
