### PR TITLE
feat: Rename Galerie to „Positionierung“ in the UI

### DIFF
--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -101,7 +101,7 @@ export default function ToggleButtonsMultiple({
         onClick={handleChange}
       >
         <GridOnIcon />
-        <span class="toolbar-text">Galerie</span>
+        <span class="toolbar-text">Positionierung</span>
       </ToggleButton>
 
       <ToggleButton

--- a/src/components/WindowManager/WindowManager.js
+++ b/src/components/WindowManager/WindowManager.js
@@ -463,7 +463,7 @@ export default function WindowManager() {
       content: (
         <Gallery
           id="gallery"
-          title="Galerie"
+          title="Positionierung"
           onHide={handleWindowHide}
           onSave={saveToLocalStorage}
           onLoad={readFromLocalStorage}


### PR DESCRIPTION
 (internal id’s stay the same).

Closes #107 

**Reviewer's task:**
- [ ] I didn't see no code smells
- [ ] The live preview works as expected -> no regressions found
