### PR TITLE
Fix (Positioning): Improve usability of custom image upload

### DIFF
--- a/src/components/Gallery/Gallery.js
+++ b/src/components/Gallery/Gallery.js
@@ -23,6 +23,7 @@ import Tabs from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";
 import ImageList from "@mui/material/ImageList";
 import ImageListItem from "@mui/material/ImageListItem";
+import Divider from "@mui/material/Divider";
 
 // Icons
 import GridOnIcon from "@mui/icons-material/GridOn";
@@ -31,6 +32,7 @@ import Grid4x4Icon from "@mui/icons-material/Grid4x4";
 import Grid3x3Icon from "@mui/icons-material/Grid3x3";
 import GridGoldenratioIcon from "@mui/icons-material/GridGoldenratio";
 import PostAddIcon from "@mui/icons-material/PostAdd";
+import AddPhotoAlternateIcon from "@mui/icons-material/AddPhotoAlternate"; // Upload Photo
 
 // Custom Components
 import ImageCarousel from "./ImageCarousel";
@@ -76,6 +78,9 @@ function Gallery(
 
   const [userImages, setUserImages] = React.useState([]);
   const [selectedImagePath, selectImage] = React.useState(defaultImages[0]);
+  const fileInput = React.useRef();
+  const imageRowRef = React.useRef();
+
   const [stageSize, setStageSize] = React.useState({ w: 720, h: 405 });
 
   const [textboxes, setTextboxes] = React.useState([]);
@@ -238,10 +243,18 @@ function Gallery(
     }
   }
 
-  function addUserImageFile(e) {
-    const [file] = e.target.files;
+  function addUserImageFile(event) {
+    const [file] = event.target.files;
     const url = URL.createObjectURL(file);
     setUserImages([...userImages, url.toString()]);
+  }
+
+  function handleFileSelect(event) {
+    addUserImageFile(event);
+    fileInput.current.value = "";
+    setTimeout(() => {
+      imageRowRef.current.scrollLeft = imageRowRef.current.scrollLeftMax + 200;
+    }, 200);
   }
 
   function deleteUserImage(event, value) {
@@ -335,6 +348,7 @@ function Gallery(
                 <GridOnIcon />
               </ToggleButton>
             </Tooltip>
+
             <Tooltip title="Textfeld hinzufügen">
               <ToggleButton
                 aria-label="Textfeld"
@@ -343,6 +357,26 @@ function Gallery(
                 onClick={addTextBox}
               >
                 <PostAddIcon />
+              </ToggleButton>
+            </Tooltip>
+          </ButtonGroup>
+          <Divider flexItem orientation="horizontal" sx={{ mx: 0.5, my: 1 }} />
+
+          <ButtonGroup>
+            <Tooltip title="Eigenes Bild hinzufügen">
+              <ToggleButton
+                value=""
+                aria-label="Bild hochladen"
+                component="label"
+              >
+                <input
+                  hidden
+                  accept="image/*"
+                  type="file"
+                  ref={fileInput}
+                  onChange={handleFileSelect}
+                />
+                <AddPhotoAlternateIcon />
               </ToggleButton>
             </Tooltip>
           </ButtonGroup>
@@ -355,6 +389,7 @@ function Gallery(
         onImageSelect={handleImageSelect}
         onFileSelect={addUserImageFile}
         onImageDelete={deleteUserImage}
+        imageRowRef={imageRowRef}
       />
     </BaseWindow>
   );

--- a/src/components/Gallery/ImageCarousel.js
+++ b/src/components/Gallery/ImageCarousel.js
@@ -1,7 +1,6 @@
 import React from "react";
 import "./ImageCarousel.scss";
 
-import AddIcon from "@mui/icons-material/Add";
 import Tooltip from "@mui/material/Tooltip";
 import ToggleButton from "@mui/material/ToggleButton";
 import DeleteIcon from "@mui/icons-material/Delete";
@@ -39,27 +38,15 @@ export const ArrowRight = ({ size = 30, color = "#000000" }) => (
   </svg>
 );
 
-// export function usePosition(imageSelectorRef) {
-//   const [prevElement, setPrevElement] = React.useState(null);
-//   const [nextElement, setNextElement] = React.useState(null);
-// }
-
 export default function ImageCarousel({
   selectedImage,
   imagePaths,
   onImageSelect,
   onFileSelect,
   onImageDelete,
+  imageRowRef,
 }) {
   const imageSelectorRef = React.useRef();
-  // const position = usePosition(imageSelectorRef);
-
-  const fileInput = React.useRef();
-
-  function handleFileSelect(event) {
-    onFileSelect(event);
-    fileInput.current.value = "";
-  }
 
   const defaultImages = imagePaths.defaultImages.map((imagePath) => (
     <img
@@ -104,24 +91,9 @@ export default function ImageCarousel({
   return (
     <>
       <div id="image-selector" ref={imageSelectorRef}>
-        <div className="image-row">
+        <div className="image-row" ref={imageRowRef}>
           {defaultImages}
           {userImages}
-          <ToggleButton
-            id="add-image-button"
-            value=""
-            aria-label="Bild hochladen"
-            component="label"
-          >
-            <input
-              hidden
-              accept="image/*"
-              type="file"
-              ref={fileInput}
-              onChange={handleFileSelect}
-            />
-            <AddIcon />
-          </ToggleButton>
         </div>
       </div>
     </>

--- a/src/components/Gallery/ImageCarousel.scss
+++ b/src/components/Gallery/ImageCarousel.scss
@@ -13,8 +13,7 @@
   }
 }
 
-.selector-preview,
-#add-image-button {
+.selector-preview {
   height: 90px;
   min-height: 80px;
   width: 150px;


### PR DESCRIPTION
- Add more prominent/always visible image-upload button to the sidebar. 
- Add automatic scrolling to end of image gallery upon adding a custom image. 
- Remove old custom image upload button & styling.

Closes #108 

**Reviewer's task:**
- [ ] I didn't see no code smells
- [ ] The live preview works as expected -> no regressions found
